### PR TITLE
Add missing comma in create_trip mutation

### DIFF
--- a/app/graphql/mutations/create_trip.rb
+++ b/app/graphql/mutations/create_trip.rb
@@ -16,7 +16,7 @@ class Mutations::CreateTrip < Mutations::BaseMutation
                 start_point: start_point,
                 end_point:   end_point,
                 travel_mode: travel_mode,
-                eta:         eta_data[:eta]
+                eta:         eta_data[:eta],
                 eta_string:  eta_data[:eta_string]
       )
   


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
Just as it says in the title. Error caused by missing comma on line 19.

Credit to Gaelyn for discovering the omission!

<!--- Describe your changes in detail -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
## What is the percent testing coverage?

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
