### PR TITLE
Sad paths for create trip mutation

### DIFF
--- a/app/graphql/types/trip_type.rb
+++ b/app/graphql/types/trip_type.rb
@@ -4,8 +4,8 @@ module Types
     field :start_point, String, null: true
     field :end_point, String, null: true
     field :travel_mode, String, null: true
-    field :eta, Integer, null: true
-    field :eta_string, String, null: true
+    field :eta, Integer, null: false
+    field :eta_string, String, null: false
     field :user_id, Integer, null: false
     field :user, Types::UserType, null: true
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false

--- a/app/services/eta_service.rb
+++ b/app/services/eta_service.rb
@@ -13,7 +13,7 @@ class EtaService
         minutes = (seconds.to_f / 60).round(0)
         minutes_text = parse_json(response)[:rows][0][:elements][0][:duration][:text]
         return { eta: minutes, eta_string: minutes_text }
-      rescue NoMethodError => e
+      rescue NoMethodError
         { eta: nil, eta_string: nil }
       end
     end

--- a/app/services/eta_service.rb
+++ b/app/services/eta_service.rb
@@ -1,17 +1,21 @@
 class EtaService
   class << self
     def get_eta(start_point, end_point, travel_mode)
-      response = conn.get('maps/api/distancematrix/json') do |f|
-        f.params['units']        = 'imperial'
-        f.params['origins']      = start_point
-        f.params['destinations'] = end_point
-        f.params['mode']         = travel_mode
+      begin
+        response = conn.get('maps/api/distancematrix/json') do |f|
+          f.params['units']        = 'imperial'
+          f.params['origins']      = start_point
+          f.params['destinations'] = end_point
+          f.params['mode']         = travel_mode
+        end
+
+        seconds = parse_json(response)[:rows][0][:elements][0][:duration][:value]
+        minutes = (seconds.to_f / 60).round(0)
+        minutes_text = parse_json(response)[:rows][0][:elements][0][:duration][:text]
+        return { eta: minutes, eta_string: minutes_text }
+      rescue NoMethodError => e
+        { eta: nil, eta_string: nil }
       end
-      
-      seconds = parse_json(response)[:rows][0][:elements][0][:duration][:value]
-      minutes = (seconds.to_f / 60).round(0)
-      minutes_text = parse_json(response)[:rows][0][:elements][0][:duration][:text]
-      return { eta: minutes, eta_string: minutes_text }
     end
 
     private

--- a/spec/fixtures/vcr_cassettes/Mutations_CreateTrip/_resolve/returns_an_error_if_a_field_is_blank.yml
+++ b/spec/fixtures/vcr_cassettes/Mutations_CreateTrip/_resolve/returns_an_error_if_a_field_is_blank.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/distancematrix/json?destinations=119%20Cuba%20Street,%20Te%20Aro,%20Wellington%206011&key=google_api_key&mode=walking&origins=&units=imperial
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.5.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 15 Jul 2021 02:08:03 GMT
+      Pragma:
+      - no-cache
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - no-cache, must-revalidate
+      Vary:
+      - Accept-Language
+      Server:
+      - mafe
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=52
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-T051=":443"; ma=2592000,h3-Q050=":443";
+        ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443";
+        ma=2592000; v="46,43"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "destination_addresses" : [],
+           "origin_addresses" : [],
+           "rows" : [],
+           "status" : "INVALID_REQUEST"
+        }
+  recorded_at: Thu, 15 Jul 2021 02:08:03 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Mutations_CreateTrip/_resolve/returns_an_error_if_field_is_blank.yml
+++ b/spec/fixtures/vcr_cassettes/Mutations_CreateTrip/_resolve/returns_an_error_if_field_is_blank.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/distancematrix/json?destinations=119%20Cuba%20Street,%20Te%20Aro,%20Wellington%206011&key=google_api_key&mode=walking&origins=&units=imperial
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.5.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 15 Jul 2021 01:39:18 GMT
+      Pragma:
+      - no-cache
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - no-cache, must-revalidate
+      Vary:
+      - Accept-Language
+      Server:
+      - mafe
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=42
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-T051=":443"; ma=2592000,h3-Q050=":443";
+        ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443";
+        ma=2592000; v="46,43"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "destination_addresses" : [],
+           "origin_addresses" : [],
+           "rows" : [],
+           "status" : "INVALID_REQUEST"
+        }
+  recorded_at: Thu, 15 Jul 2021 01:39:18 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Mutations_CreateTrip/_resolve/shows_error_if_addresses_are_invalid.yml
+++ b/spec/fixtures/vcr_cassettes/Mutations_CreateTrip/_resolve/shows_error_if_addresses_are_invalid.yml
@@ -21,7 +21,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Thu, 15 Jul 2021 02:48:57 GMT
+      - Thu, 15 Jul 2021 03:15:11 GMT
       Pragma:
       - no-cache
       Expires:
@@ -37,7 +37,7 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Server-Timing:
-      - gfet4t7; dur=280
+      - gfet4t7; dur=316
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-T051=":443"; ma=2592000,h3-Q050=":443";
         ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443";
@@ -61,5 +61,5 @@ http_interactions:
            ],
            "status" : "OK"
         }
-  recorded_at: Thu, 15 Jul 2021 02:48:57 GMT
+  recorded_at: Thu, 15 Jul 2021 03:15:11 GMT
 recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Mutations_CreateTrip/_resolve/shows_error_if_addresses_are_invalid.yml
+++ b/spec/fixtures/vcr_cassettes/Mutations_CreateTrip/_resolve/shows_error_if_addresses_are_invalid.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/distancematrix/json?destinations=Saturn,%20Outer%20Space&key=google_api_key&mode=walking&origins=Mars,%20Outer%20Space&units=imperial
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.5.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 15 Jul 2021 02:48:57 GMT
+      Pragma:
+      - no-cache
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - no-cache, must-revalidate
+      Vary:
+      - Accept-Language
+      Server:
+      - mafe
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=280
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-T051=":443"; ma=2592000,h3-Q050=":443";
+        ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443";
+        ma=2592000; v="46,43"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+           "destination_addresses" : [ "1 Tranquility Base, Huntsville, AL 35805, USA" ],
+           "origin_addresses" : [ "" ],
+           "rows" : [
+              {
+                 "elements" : [
+                    {
+                       "status" : "NOT_FOUND"
+                    }
+                 ]
+              }
+           ],
+           "status" : "OK"
+        }
+  recorded_at: Thu, 15 Jul 2021 02:48:57 GMT
+recorded_with: VCR 6.0.0

--- a/spec/graphql/mutations/create_trip_spec.rb
+++ b/spec/graphql/mutations/create_trip_spec.rb
@@ -10,59 +10,59 @@ module Mutations
           @user = create(:user)
         end
         it 'creates a trip', :vcr do
-          def query
-            <<~GQL
-            mutation {
-              createTrip(
-              input: {
-                startPoint: "60/66 Kingsford Smith Street, Lyall Bay, Wellington 6022",
-                endPoint: "119 Cuba Street, Te Aro, Wellington 6011",
-                travelMode: "walking",
-                userId: #{@user.id}
-              }
-              ) {
-                  trip {
-                  id
-                  startPoint
-                  endPoint
-                  travelMode
-                  eta
-                  etaString
-                  userId
-                  }
-                }
-              }
-            GQL
-          end
+          # def query
+          #   <<~GQL
+          #   mutation {
+          #     createTrip(
+          #     input: {
+          #       startPoint: "60/66 Kingsford Smith Street, Lyall Bay, Wellington 6022",
+          #       endPoint: "119 Cuba Street, Te Aro, Wellington 6011",
+          #       travelMode: "walking",
+          #       userId: #{@user.id}
+          #     }
+          #     ) {
+          #         trip {
+          #         id
+          #         startPoint
+          #         endPoint
+          #         travelMode
+          #         eta
+          #         etaString
+          #         userId
+          #         }
+          #       }
+          #     }
+          #   GQL
+          # end
           expect(Trip.count).to eq(0)
           post '/graphql', params: { query: query }
           expect(Trip.count).to eq(1)
         end
         it 'returns a trip', :vcr do
-          def query
-            <<~GQL
-            mutation {
-              createTrip(
-              input: {
-                startPoint: "60/66 Kingsford Smith Street, Lyall Bay, Wellington 6022",
-                endPoint: "119 Cuba Street, Te Aro, Wellington 6011",
-                travelMode: "walking",
-                userId: #{@user.id}
-              }
-              ) {
-                  trip {
-                  id
-                  startPoint
-                  endPoint
-                  travelMode
-                  eta
-                  etaString
-                  userId
-                  }
-                }
-              }
-            GQL
-          end
+          # def query
+          #   <<~GQL
+          #   mutation {
+          #     createTrip(
+          #     input: {
+          #       startPoint: "60/66 Kingsford Smith Street, Lyall Bay, Wellington 6022",
+          #       endPoint: "119 Cuba Street, Te Aro, Wellington 6011",
+          #       travelMode: "walking",
+          #       userId: #{@user.id}
+          #     }
+          #     ) {
+          #         trip {
+          #         id
+          #         startPoint
+          #         endPoint
+          #         travelMode
+          #         eta
+          #         etaString
+          #         userId
+          #         }
+          #       }
+          #     }
+          #   GQL
+          # end
           post '/graphql', params: { query: query }
           json = JSON.parse(response.body)
           data = json['data']['createTrip']
@@ -73,6 +73,120 @@ module Mutations
           expect(data['trip']['etaString']).to eq('1 hour 10 mins')
           expect(data['trip']['userId']).to eq(@user.id)
         end
+
+        it 'returns an error if a field is blank', :vcr do
+          post '/graphql', params: { query: blank_field_query }
+          json = JSON.parse(response.body)
+          expect(json['errors'][0]['message']).to eq("Cannot return null for non-nullable field CreateTripPayload.trip")
+        end
+
+        it 'must have a user id' do
+          post '/graphql', params: { query: no_user_query }
+          json = JSON.parse(response.body)
+          expect(json['errors'][0]['message']).to eq("Argument 'userId' on InputObject 'CreateTripInput' is required. Expected type Int!")
+        end
+
+        it 'shows error if addresses are invalid', :vcr do
+          post '/graphql', params: { query: invalid_address_query }
+          json = JSON.parse(response.body)
+          expect(json['data']['createTrip']['trip']['eta']).to be_nil
+          expect(json['data']['createTrip']['trip']['eta_string']).to be_nil
+        end
+      end
+      def query
+        <<~GQL
+        mutation {
+          createTrip(
+          input: {
+            startPoint: "60/66 Kingsford Smith Street, Lyall Bay, Wellington 6022",
+            endPoint: "119 Cuba Street, Te Aro, Wellington 6011",
+            travelMode: "walking",
+            userId: #{@user.id}
+          }
+          ) {
+              trip {
+              id
+              startPoint
+              endPoint
+              travelMode
+              eta
+              etaString
+              userId
+              }
+            }
+          }
+        GQL
+      end
+      def blank_field_query
+        <<~GQL
+        mutation {
+          createTrip(
+          input: {
+            startPoint: "",
+            endPoint: "119 Cuba Street, Te Aro, Wellington 6011",
+            travelMode: "walking",
+            userId: #{@user.id}
+          }
+          ) {
+              trip {
+              id
+              startPoint
+              endPoint
+              travelMode
+              eta
+              etaString
+              userId
+              }
+            }
+          }
+        GQL
+      end
+      def no_user_query
+        <<~GQL
+        mutation {
+          createTrip(
+          input: {
+            startPoint: "60/66 Kingsford Smith Street, Lyall Bay, Wellington 6022",
+            endPoint: "119 Cuba Street, Te Aro, Wellington 6011",
+            travelMode: "walking"
+          }
+          ) {
+              trip {
+              id
+              startPoint
+              endPoint
+              travelMode
+              eta
+              etaString
+              userId
+              }
+            }
+          }
+        GQL
+      end
+      def invalid_address_query
+        <<~GQL
+        mutation {
+          createTrip(
+          input: {
+            startPoint: "Mars, Outer Space",
+            endPoint: "Saturn, Outer Space",
+            travelMode: "walking"
+            userId: #{@user.id}
+          }
+          ) {
+              trip {
+              id
+              startPoint
+              endPoint
+              travelMode
+              eta
+              etaString
+              userId
+              }
+            }
+          }
+        GQL
       end
     end
   end

--- a/spec/graphql/mutations/create_trip_spec.rb
+++ b/spec/graphql/mutations/create_trip_spec.rb
@@ -89,8 +89,8 @@ module Mutations
         it 'shows error if addresses are invalid', :vcr do
           post '/graphql', params: { query: invalid_address_query }
           json = JSON.parse(response.body)
-          expect(json['data']['createTrip']['trip']['eta']).to be_nil
-          expect(json['data']['createTrip']['trip']['eta_string']).to be_nil
+          expect(json['data']['createTrip']).to be_nil
+          expect(json['errors'][0]['message']).to eq("Cannot return null for non-nullable field Trip.eta")
         end
       end
       def query


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->

- Made sad path tests for blank address field, missing user_id, and invalid addresses for create_trip mutation.
- Added a rescue to EtaService if it returns an `Undefined method for nil class` error.  I'm not totally confident this is the best way to do it but it was easier to send eta and eta_string over as nil vs just getting the NoMethodError.
```ruby
rescue NoMethodError
  { eta: nil, eta_string: nil }
end
```
- Also set eta and eta_string to null : false in `app/graphql/types/trip_type.rb` so that it returns an error if no eta can be calculated when creating a trip.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Sad path testing and proper error returns for create trip mutation.
<!--- If it fixes an open issue, please link to the issue here. -->
closes #31 
## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
See above. 
Made more queries in test similar to happy path test, but with desired errors.
## What is the percent testing coverage?
92.27% overall, create_trip.rb is at 100%

## Screenshots (if appropriate):
<img width="712" alt="Screen Shot 2021-07-14 at 9 50 09 PM" src="https://user-images.githubusercontent.com/57960885/125724951-67ca48c7-44c6-4839-84ba-69ed150ddd3c.png">
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
