### PR TITLE
Add sad path testing for create mutation.

### DIFF
--- a/app/graphql/mutations/create_contact.rb
+++ b/app/graphql/mutations/create_contact.rb
@@ -9,7 +9,7 @@ class Mutations::CreateContact < Mutations::BaseMutation
 
   def resolve(first_name:, last_name:, phone_number:, user_id:)
     contact = User.find(user_id).contacts.new(first_name: first_name, last_name: last_name, phone_number: phone_number)
-
+    
     if contact.save
       {
         contact: contact,

--- a/app/graphql/mutations/create_trip.rb
+++ b/app/graphql/mutations/create_trip.rb
@@ -11,6 +11,7 @@ class Mutations::CreateTrip < Mutations::BaseMutation
 
   def resolve(start_point:, end_point:, travel_mode:, user_id:)
     eta_data = EtaService.get_eta(start_point, end_point, travel_mode)
+    
     trip = User.find(user_id).trips.new(
                 start_point: start_point,
                 end_point:   end_point,

--- a/spec/graphql/mutations/create_contact_spec.rb
+++ b/spec/graphql/mutations/create_contact_spec.rb
@@ -9,6 +9,7 @@ module Mutations
           Contact.destroy_all
           @user = create(:user)
         end
+
         it 'creates a contact' do
           def query
             <<~GQL
@@ -35,6 +36,7 @@ module Mutations
           post '/graphql', params: { query: query }
           expect(Contact.count).to eq(1)
         end
+
         it 'returns a contact' do
           def query
             <<~GQL
@@ -64,6 +66,99 @@ module Mutations
           expect(data['contact']['firstName']).to eq('Samara')
           expect(data['contact']['lastName']).to eq('Rosenberg')
           expect(data['contact']['phoneNumber']).to eq('+13038765432')
+        end
+
+        it 'returns an error with no phoneNumber input' do
+          def query
+            <<~GQL
+            mutation {
+              createContact(
+              input: {
+                firstName: "Samara"
+                lastName: "Rosenberg"
+                phoneNumber: ""
+                userId: #{@user.id}
+              }
+              ) {
+                  contact {
+                  id
+                  firstName
+                  lastName
+                  phoneNumber
+                  }
+                }
+              }
+            GQL
+          end
+          post '/graphql', params: { query: query }
+          
+          json = JSON.parse(response.body)
+          expect(json).to be_a(Hash)
+          expect(json['errors']).to be_an(Array)
+          expect(json['errors'][0]['message']).to be_a(String)
+          expect(json['errors'][0]['message']).to eq("Cannot return null for non-nullable field CreateContactPayload.contact")
+        end
+
+        it 'returns an error with no fristName input' do
+          def query
+            <<~GQL
+            mutation {
+              createContact(
+              input: {
+                firstName: ""
+                lastName: "Rosenberg"
+                phoneNumber: "+13038765432"
+                userId: #{@user.id}
+              }
+              ) {
+                  contact {
+                  id
+                  firstName
+                  lastName
+                  phoneNumber
+                  }
+                }
+              }
+            GQL
+          end
+          post '/graphql', params: { query: query }
+
+          json = JSON.parse(response.body)
+          expect(json).to be_a(Hash)
+          expect(json['errors']).to be_an(Array)
+          expect(json['errors'][0]['message']).to be_a(String)
+          expect(json['errors'][0]['message']).to eq("Cannot return null for non-nullable field CreateContactPayload.contact")
+        end
+
+        it 'returns an error with no lastName input' do
+          def query
+            <<~GQL
+            mutation {
+              createContact(
+              input: {
+                firstName: "Sally"
+                lastName: ""
+                phoneNumber: "+13038765432"
+                userId: #{@user.id}
+              }
+              ) {
+                  contact {
+                  id
+                  firstName
+                  lastName
+                  phoneNumber
+                  }
+                }
+              }
+            GQL
+          end
+          post '/graphql', params: { query: query }
+
+          json = JSON.parse(response.body)
+          expect(json).to be_a(Hash)
+          expect(json['errors']).to be_an(Array)
+          expect(json['errors'][0]['message']).to be_a(String)
+          expect(json['errors'][0]['message']).to eq("Cannot return null for non-nullable field CreateContactPayload.contact")
         end
       end
     end


### PR DESCRIPTION
Co-authored-by: Gaelyn Cooper <57960885+gaelyn@users.noreply.github.com>
Co-authored-by: Joe Mecha <72046344+joemecha@users.noreply.github.com>

<!--- Provide a general summary of your changes in the Title above -->
## Description
- added sad path testing for absent first name, last name and phone number fields.
<!--- Describe your changes in detail -->
## Motivation and Context
- added sad path testing for absent first name, last name and phone number fields.
<!--- Why is this change required? What problem does it solve? -->
- added sad path testing where only happy path was present
- increase test coverage
<!--- If it fixes an open issue, please link to the issue here. -->
## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
- empty string for all 3 required input fields

<!--- Include details of your testing environment, tests ran to see how -->
- app/graphql/mutations/create_contact.rb, 100% coverage
- 92.18% app full test coverage

<!--- your change affects other areas of the code, etc. -->
## What is the percent testing coverage?
- 92.18% app full test coverage
## Screenshots (if appropriate):
<img width="964" alt="Screen Shot 2021-07-15 at 9 34 45 AM" src="https://user-images.githubusercontent.com/56099485/125815704-1bcd745c-d995-44aa-bd8d-4189d69e46b9.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
